### PR TITLE
Flexible version of request library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.22.0
-requests-oauthlib==1.2.0
+requests>=2.22.0, ==2.*
+requests-oauthlib>=1.2.0, ==1.*


### PR DESCRIPTION
Modified requirements.txt so that higher versions of requests are allowed, as long as they begin with "2.*" .
Same thing with any version of requests-oauthlib that is "1.*" .